### PR TITLE
For CloudFront, the ACM certificates must always be in us-east-1

### DIFF
--- a/acm_handler.py
+++ b/acm_handler.py
@@ -11,7 +11,7 @@ import cfn_resource
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
-acm = boto3.client('acm')
+acm = boto3.client('acm', region_name='us-east-1')
 
 def await_validation(domain, context):
     # as long as we have at least 10 seconds left

--- a/cloudfront_associator.py
+++ b/cloudfront_associator.py
@@ -10,7 +10,7 @@ log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
 cloudfront = boto3.client('cloudfront')
-acm = boto3.client('acm')
+acm = boto3.client('acm', region_name='us-east-1')
 
 def check_properties(event):
     properties = event['ResourceProperties']


### PR DESCRIPTION
ACM is available in more regions, but for CloudFront, they must always be created and discovered in us-east-1.
